### PR TITLE
1优化后台文章预览访问连接 剔除多余 2修复join（） 参数引起的 标签文章的 500报错

### DIFF
--- a/app/portal/service/ApiService.php
+++ b/app/portal/service/ApiService.php
@@ -180,9 +180,9 @@ class ApiService
         $portalPostModel = new PortalPostModel();
 
         $where = [
-            'post.post_status' => 1,
-            'post.post_type'   => 1,
-            'post.delete_time' => 0
+            ['post.post_status' ,'=', 1],
+            ['post.post_type'   ,'=', 1],
+            ['post.delete_time' ,'=', 0]
         ];
 
         $paramWhere = empty($param['where']) ? '' : $param['where'];
@@ -193,18 +193,14 @@ class ApiService
         $relation = empty($param['relation']) ? '' : $param['relation'];
         $tagId    = empty($param['tag_id']) ? '' : $param['tag_id'];
 
-        $join = [
-            //['__USER__ user', 'post.user_id = user.id'],
-        ];
-
+        $articles = $portalPostModel->alias('post');
         if (empty($tagId)) {
             return null;
 
         } else {
             $field = !empty($param['field']) ? $param['field'] : 'post.*';
-            array_push($join, ['__PORTAL_TAG_POST__ tag_post', 'post.id = tag_post.post_id']);
-
-            $where['tag_post.tag_id'] = $tagId;
+            $articles =  $articles->join('portal_tag_post tag_post', 'post.id = tag_post.post_id');
+            $where[] = ['tag_post.tag_id','=',$tagId];
         }
 
         $wherePublishedTime = function (Query $query) {
@@ -212,9 +208,7 @@ class ApiService
                 ->where('post.published_time', '<', time());
         };
 
-
-        $articles = $portalPostModel->alias('post')->field($field)
-            ->join($join)
+        $articles = $articles->field($field)
             ->where($where)
             ->where($paramWhere)
             ->where($wherePublishedTime)

--- a/public/themes/admin_simpleboot3/portal/admin_article/index.html
+++ b/public/themes/admin_simpleboot3/portal/admin_article/index.html
@@ -69,9 +69,6 @@
                         <input type="checkbox" class="js-check-all" data-direction="x" data-checklist="js-check-x">
                     </label>
                 </th>
-                <notempty name="category">
-                    <th width="50">{:lang('SORT')}</th>
-                </notempty>
                 <th width="50">ID</th>
                 <th>标题</th>
                 <th>分类</th>
@@ -91,19 +88,13 @@
                         <input type="checkbox" class="js-check" data-yid="js-check-y" data-xid="js-check-x" name="ids[]"
                                value="{$vo.id}" title="ID:{$vo.id}">
                     </td>
-                    <notempty name="category">
-                        <td>
-                            <input name="list_orders[{$vo.post_category_id}]" class="input-order" type="text"
-                                   value="{$vo.list_order}">
-                        </td>
-                    </notempty>
                     <td><b>{$vo.id}</b></td>
                     <td>
-                        <notempty name="category">
-                            <a href="{:cmf_url('portal/Article/index',array('id'=>$vo['id'],'cid'=>$vo['category_id']))}"
+                        <notempty name="vo.categories">
+                            <a href="{:cmf_url('portal/Article/index',array('id'=>$vo['id'],'cid'=>$vo['categories'][0]['id']))}"
                                target="_blank">{$vo.post_title}</a>
                             <else/>
-                            <a href="{:cmf_url('portal/Article/index',array('id'=>$vo['id']))}"
+                            <a href="{:cmf_url('portal/Article/index',array('id'=>$vo.id))}"
                                target="_blank">{$vo.post_title}</a>
                         </notempty>
                     </td>


### PR DESCRIPTION

* 优化后台文章预览访问连接 剔除多余
* 修复join（） 参数引起的 标签文章的 500报错